### PR TITLE
Updated library to work with `X-Total-Count` header and new GetApplications endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SCORM Cloud Rest API
 - API version: 2.0
-    - Build date: 2022-09-26T11:33:06.485-05:00
+    - Build date: 2022-11-09T17:35:58.398-06:00
 
 REST API used for SCORM Cloud integrations.
 
@@ -42,7 +42,7 @@ Add this dependency to your project's POM:
 <dependency>
     <groupId>com.rusticisoftware.cloud.v2.client</groupId>
     <artifactId>scormcloud-api-v2-client</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -52,7 +52,7 @@ Add this dependency to your project's POM:
 Add this dependency to your project's build file:
 
 ```groovy
-compile "com.rusticisoftware.cloud.v2.client:scormcloud-api-v2-client:2.1.0"
+compile "com.rusticisoftware.cloud.v2.client:scormcloud-api-v2-client:3.0.0"
 ```
 
 #### Others
@@ -65,7 +65,7 @@ mvn clean package
 
 Then manually install the following JARs:
 
-* `target/scormcloud-api-v2-client-2.1.0.jar`
+* `target/scormcloud-api-v2-client-3.0.0.jar`
 * `target/lib/*.jar`
 
 ## Tips and Tricks
@@ -376,13 +376,13 @@ public class ScormCloud_Java_Sample {
         // Additional filters can be provided to this call to get a subset
         // of all courses.
         CourseApi courseApi = new CourseApi();
-        CourseListSchema response = courseApi.getCourses(null, null, null, null, null, null, null, null, null, null);
+        CourseListSchema response = courseApi.getCourses(null, null, null, null, null, null, null, null, null, null, null);
 
         // This call is paginated, with a token provided if more results exist
         List<CourseSchema> courseList = response.getCourses();
         while (response.getMore() != null)
         {
-            response = courseApi.getCourses(null, null, null, null, null, null, null, response.getMore(), null, null);
+            response = courseApi.getCourses(null, null, null, null, null, null, null, response.getMore(), null, null, null);
             courseList.addAll(response.getCourses());
         }
 
@@ -412,13 +412,13 @@ public class ScormCloud_Java_Sample {
         // Additional filters can be provided to this call to get a subset
         // of all registrations.
         RegistrationApi registrationApi = new RegistrationApi();
-        RegistrationListSchema response = registrationApi.getRegistrations(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        RegistrationListSchema response = registrationApi.getRegistrations(null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 
         // This call is paginated, with a token provided if more results exist
         List<RegistrationSchema> registrationList = response.getRegistrations();
         while (response.getMore() != null)
         {
-            response = registrationApi.getRegistrations(null, null, null, null, null, null, null, null, null, response.getMore(), null, null, null);
+            response = registrationApi.getRegistrations(null, null, null, null, null, null, null, null, null, response.getMore(), null, null, null, null);
             registrationList.addAll(response.getRegistrations());
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'idea'
 apply plugin: 'eclipse'
 
 group = 'com.rusticisoftware.cloud.v2.client'
-version = '2.1.0'
+version = '3.0.0'
 
 buildscript {
     repositories {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file(".")).
   settings(
     organization := "com.rusticisoftware.cloud.v2.client",
     name := "scormcloud-api-v2-client",
-    version := "2.1.0",
+    version := "3.0.0",
     scalaVersion := "2.11.4",
     scalacOptions ++= Seq("-feature"),
     javacOptions in compile ++= Seq("-Xlint:deprecation"),

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rusticisoftware.cloud.v2.client</groupId>
     <artifactId>scormcloud-api-v2-client</artifactId>
     <packaging>jar</packaging>
     <name>scormcloud-api-v2-client</name>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <url>https://rusticisoftware.com/products/scorm-cloud/api/</url>
     <description>Swagger Generated Java Client for SCORM Cloud API v2</description>
     <scm>
         <connection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</developerConnection>
         <url>https://github.com/RusticiSoftware/scormcloud-api-v2-client-java</url>
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
 
     <licenses>
         <license>
@@ -277,7 +277,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-core-version>1.5.24</swagger-core-version>
             <jersey-version>2.29.1</jersey-version>
-        <jackson-version>2.11.4</jackson-version>
+        <jackson-version>2.13.4</jackson-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
     </properties>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.rusticisoftware.cloud.v2.client</groupId>
     <artifactId>scormcloud-api-v2-client</artifactId>
     <packaging>jar</packaging>
     <name>scormcloud-api-v2-client</name>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <url>https://rusticisoftware.com/products/scorm-cloud/api/</url>
     <description>Swagger Generated Java Client for SCORM Cloud API v2</description>
     <scm>
         <connection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</developerConnection>
         <url>https://github.com/RusticiSoftware/scormcloud-api-v2-client-java</url>
-    </scm>
+      <tag>scormcloud-api-v2-client-3.0.0</tag>
+  </scm>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
     <artifactId>scormcloud-api-v2-client</artifactId>
     <packaging>jar</packaging>
     <name>scormcloud-api-v2-client</name>
-    <version>3.0.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <url>https://rusticisoftware.com/products/scorm-cloud/api/</url>
     <description>Swagger Generated Java Client for SCORM Cloud API v2</description>
     <scm>
         <connection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</connection>
         <developerConnection>scm:git:git@github.com:RusticiSoftware/scormcloud-api-v2-client-java.git</developerConnection>
         <url>https://github.com/RusticiSoftware/scormcloud-api-v2-client-java</url>
-      <tag>scormcloud-api-v2-client-3.0.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <licenses>

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/ApiClient.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/ApiClient.java
@@ -51,7 +51,6 @@ import com.rusticisoftware.cloud.v2.client.auth.HttpBasicAuth;
 import com.rusticisoftware.cloud.v2.client.auth.ApiKeyAuth;
 import com.rusticisoftware.cloud.v2.client.auth.OAuth;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApiClient {
   protected Map<String, String> defaultHeaderMap = new HashMap<String, String>();
   protected String basePath = "https://cloud.scorm.com/api/v2/";
@@ -74,14 +73,13 @@ public class ApiClient {
     this.dateFormat = new RFC3339DateFormat();
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/2.1.0/java");
+    setUserAgent("Swagger-Codegen/3.0.0/java");
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();
     authentications.put("APP_MANAGEMENT", new HttpBasicAuth());
     authentications.put("APP_NORMAL", new HttpBasicAuth());
     authentications.put("OAUTH", new OAuth());
-    authentications.put("UNSECURED", new HttpBasicAuth());
     // Prevent the authentications from being modified.
     authentications = Collections.unmodifiableMap(authentications);
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/ApiException.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/ApiException.java
@@ -16,7 +16,6 @@ package com.rusticisoftware.cloud.v2.client;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApiException extends Exception {
     private int code = 0;
     private Map<String, List<String>> responseHeaders = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/Configuration.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/Configuration.java
@@ -13,7 +13,6 @@
 
 package com.rusticisoftware.cloud.v2.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class Configuration {
     private static ApiClient defaultApiClient = new ApiClient();
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/JSON.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/JSON.java
@@ -8,7 +8,6 @@ import java.text.DateFormat;
 
 import javax.ws.rs.ext.ContextResolver;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class JSON implements ContextResolver<ObjectMapper> {
   private ObjectMapper mapper;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/Pair.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/Pair.java
@@ -13,7 +13,6 @@
 
 package com.rusticisoftware.cloud.v2.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class Pair {
     private String name = "";
     private String value = "";

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/StringUtil.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/StringUtil.java
@@ -13,7 +13,6 @@
 
 package com.rusticisoftware.cloud.v2.client;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class StringUtil {
   /**
    * Check if the given array contains the given value (with case-insensitive comparison).

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/AboutApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/AboutApi.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class AboutApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/ApplicationManagementApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/ApplicationManagementApi.java
@@ -8,6 +8,7 @@ import com.rusticisoftware.cloud.v2.client.Pair;
 
 import javax.ws.rs.core.GenericType;
 
+import com.rusticisoftware.cloud.v2.client.model.ApplicationInfoListSchema;
 import com.rusticisoftware.cloud.v2.client.model.ApplicationInfoSchema;
 import com.rusticisoftware.cloud.v2.client.model.ApplicationListSchema;
 import com.rusticisoftware.cloud.v2.client.model.ApplicationRequestSchema;
@@ -16,6 +17,7 @@ import com.rusticisoftware.cloud.v2.client.model.CredentialCreatedSchema;
 import com.rusticisoftware.cloud.v2.client.model.CredentialListSchema;
 import com.rusticisoftware.cloud.v2.client.model.CredentialRequestSchema;
 import com.rusticisoftware.cloud.v2.client.model.MessageSchema;
+import java.time.OffsetDateTime;
 import com.rusticisoftware.cloud.v2.client.model.SettingListSchema;
 import com.rusticisoftware.cloud.v2.client.model.SettingsPostSchema;
 import com.rusticisoftware.cloud.v2.client.model.StringResultSchema;
@@ -27,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationManagementApi {
   private ApiClient apiClient;
 
@@ -495,21 +496,25 @@ public class ApplicationManagementApi {
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
       }
   /**
-   * Use the Application Management App to get a list of Applications 
-   * Returns a list of all applications which are in this Realm.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource. 
+   * (Deprecated) Use the Application Management App to get basic data about all Applications in a Realm 
+   * Returns a list of all applications which are in this Realm.  &gt;**Deprecated:** &gt;It is advised to use GetApplications instead of this endpoint, as this one now exists for backwards  compatibility.  This endpoint returns very limited data about **all** applications in a Realm and is not  paginated.  Because of this, this endpoint can run into issues and have very slow performance when attempting to  pull data for accounts with many applications.  The GetApplications endpoint alleviates this problem by using pagination to return a limited amount of applications at once, while also providing much more detail about every  application present in a Realm.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource. 
    * @return ApplicationListSchema
    * @throws ApiException if fails to make API call
+   * @deprecated Use GetApplications instead.
    */
+  @Deprecated
   public ApplicationListSchema getApplicationList() throws ApiException {
     return getApplicationListWithHttpInfo().getData();
       }
 
   /**
-   * Use the Application Management App to get a list of Applications 
-   * Returns a list of all applications which are in this Realm.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource. 
+   * (Deprecated) Use the Application Management App to get basic data about all Applications in a Realm 
+   * Returns a list of all applications which are in this Realm.  &gt;**Deprecated:** &gt;It is advised to use GetApplications instead of this endpoint, as this one now exists for backwards  compatibility.  This endpoint returns very limited data about **all** applications in a Realm and is not  paginated.  Because of this, this endpoint can run into issues and have very slow performance when attempting to  pull data for accounts with many applications.  The GetApplications endpoint alleviates this problem by using pagination to return a limited amount of applications at once, while also providing much more detail about every  application present in a Realm.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource. 
    * @return ApiResponse&lt;ApplicationListSchema&gt;
    * @throws ApiException if fails to make API call
+   * @deprecated Use GetApplicationsWithHttpInfo instead.
    */
+  @Deprecated
   public ApiResponse<ApplicationListSchema> getApplicationListWithHttpInfo() throws ApiException {
     Object localVarPostBody = null;
     
@@ -537,6 +542,81 @@ public class ApplicationManagementApi {
     String[] localVarAuthNames = new String[] { "APP_MANAGEMENT", "OAUTH" };
 
     GenericType<ApplicationListSchema> localVarReturnType = new GenericType<ApplicationListSchema>() {};
+    return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+      }
+  /**
+   * Use the Application Management App to get a detailed list of Applications 
+   * Returns a list of applications. Can be filtered using the request parameters to provide a subset of results.  This endpoint caches the course and registration counts of an application for 24 hours if either  &#x60;includeCourseCount&#x60; or &#x60;includeRegistrationCount&#x60; parameters, respectively, are set to &#x60;true&#x60;. Since these values are cached for an extended period, any changes made to the number of courses or  registrations in an application will not be reflected in the results of this endpoint until the caching period has passed.  &gt;**Note:** &gt;This request is paginated and will only provide a limited amount of resources at a time. If there are more results to be collected, a &#x60;more&#x60; token provided with the response which can be passed to get the next page of results. When passing this token, no other filter parameters can be sent as part of the request. The resources will continue to respect the filters passed in by the original request.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource.  &gt;**Info:** &gt;If you want to get an up-to-date value of the course or registration count for a single application within the caching period, use the GetApplicationInfo endpoint with &#x60;includeCourseCount&#x60; and/or &#x60;includeRegistrationCount&#x60; set to &#x60;true&#x60;.  GetApplicationInfo *always* gathers the most up-to-date values and overwrites them in the cache, resetting the caching period for that application. 
+   * @param since Filter by ISO 8601 TimeStamp inclusive (defaults to UTC) (optional)
+   * @param until Filter by ISO 8601 TimeStamp inclusive (defaults to UTC) (optional)
+   * @param datetimeFilter Specifies field that &#x60;since&#x60; and &#x60;until&#x60; parameters are applied against (optional, default to updated)
+   * @param filter Optional string which filters results by a specified field (described by filterBy). (optional)
+   * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to app_id)
+   * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
+   * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeCourseCount Include a count of courses for the application. (optional, default to false)
+   * @param includeRegistrationCount Include a count of registrations created for the application during the current billing period. (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
+   * @return ApplicationInfoListSchema
+   * @throws ApiException if fails to make API call
+   */
+  public ApplicationInfoListSchema getApplications(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeCourseCount, Boolean includeRegistrationCount, Boolean includeTotalCount) throws ApiException {
+    return getApplicationsWithHttpInfo(since, until, datetimeFilter, filter, filterBy, orderBy, more, includeCourseCount, includeRegistrationCount, includeTotalCount).getData();
+      }
+
+  /**
+   * Use the Application Management App to get a detailed list of Applications 
+   * Returns a list of applications. Can be filtered using the request parameters to provide a subset of results.  This endpoint caches the course and registration counts of an application for 24 hours if either  &#x60;includeCourseCount&#x60; or &#x60;includeRegistrationCount&#x60; parameters, respectively, are set to &#x60;true&#x60;. Since these values are cached for an extended period, any changes made to the number of courses or  registrations in an application will not be reflected in the results of this endpoint until the caching period has passed.  &gt;**Note:** &gt;This request is paginated and will only provide a limited amount of resources at a time. If there are more results to be collected, a &#x60;more&#x60; token provided with the response which can be passed to get the next page of results. When passing this token, no other filter parameters can be sent as part of the request. The resources will continue to respect the filters passed in by the original request.  &gt;**Note:** &gt;Each Realm has a special application called the **Application Management Application**.  When using this special application&#39;s credentials to authenticate with the API, you are able to perform actions on all the other applications within that Realm (and only those actions, this isn&#39;t a general purpose credential).  You can list, add, update, and delete both applications and credentials with this API resource.  &gt;**Info:** &gt;If you want to get an up-to-date value of the course or registration count for a single application within the caching period, use the GetApplicationInfo endpoint with &#x60;includeCourseCount&#x60; and/or &#x60;includeRegistrationCount&#x60; set to &#x60;true&#x60;.  GetApplicationInfo *always* gathers the most up-to-date values and overwrites them in the cache, resetting the caching period for that application. 
+   * @param since Filter by ISO 8601 TimeStamp inclusive (defaults to UTC) (optional)
+   * @param until Filter by ISO 8601 TimeStamp inclusive (defaults to UTC) (optional)
+   * @param datetimeFilter Specifies field that &#x60;since&#x60; and &#x60;until&#x60; parameters are applied against (optional, default to updated)
+   * @param filter Optional string which filters results by a specified field (described by filterBy). (optional)
+   * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to app_id)
+   * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
+   * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeCourseCount Include a count of courses for the application. (optional, default to false)
+   * @param includeRegistrationCount Include a count of registrations created for the application during the current billing period. (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
+   * @return ApiResponse&lt;ApplicationInfoListSchema&gt;
+   * @throws ApiException if fails to make API call
+   */
+  public ApiResponse<ApplicationInfoListSchema> getApplicationsWithHttpInfo(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeCourseCount, Boolean includeRegistrationCount, Boolean includeTotalCount) throws ApiException {
+    Object localVarPostBody = null;
+    
+    // create path and map variables
+    String localVarPath = "/appManagement/applicationList";
+
+    // query params
+    List<Pair> localVarQueryParams = new ArrayList<Pair>();
+    Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+    Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "since", since));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "until", until));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "datetimeFilter", datetimeFilter));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "filter", filter));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeCourseCount", includeCourseCount));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeRegistrationCount", includeRegistrationCount));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
+
+    
+    
+    final String[] localVarAccepts = {
+      "application/json"
+    };
+    final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+
+    final String[] localVarContentTypes = {
+      "application/json"
+    };
+    final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+    String[] localVarAuthNames = new String[] { "APP_MANAGEMENT", "OAUTH" };
+
+    GenericType<ApplicationInfoListSchema> localVarReturnType = new GenericType<ApplicationInfoListSchema>() {};
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
       }
   /**

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/AuthenticationApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/AuthenticationApi.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class AuthenticationApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/ContentConnectorsApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/ContentConnectorsApi.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ContentConnectorsApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/CourseApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/CourseApi.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseApi {
   private ApiClient apiClient;
 
@@ -1626,11 +1625,12 @@ if (file != null)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeCourseMetadata Include course metadata in the results. If the course has no metadata, adding this parameter has no effect. (optional, default to false)
    * @param includeRegistrationCount Include the registration count in the results (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return CourseListSchema
    * @throws ApiException if fails to make API call
    */
-  public CourseListSchema getCourses(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeCourseMetadata, Boolean includeRegistrationCount) throws ApiException {
-    return getCoursesWithHttpInfo(since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeCourseMetadata, includeRegistrationCount).getData();
+  public CourseListSchema getCourses(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeCourseMetadata, Boolean includeRegistrationCount, Boolean includeTotalCount) throws ApiException {
+    return getCoursesWithHttpInfo(since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeCourseMetadata, includeRegistrationCount, includeTotalCount).getData();
       }
 
   /**
@@ -1646,10 +1646,11 @@ if (file != null)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeCourseMetadata Include course metadata in the results. If the course has no metadata, adding this parameter has no effect. (optional, default to false)
    * @param includeRegistrationCount Include the registration count in the results (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;CourseListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<CourseListSchema> getCoursesWithHttpInfo(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeCourseMetadata, Boolean includeRegistrationCount) throws ApiException {
+  public ApiResponse<CourseListSchema> getCoursesWithHttpInfo(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeCourseMetadata, Boolean includeRegistrationCount, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -1670,6 +1671,7 @@ if (file != null)
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeCourseMetadata", includeCourseMetadata));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeRegistrationCount", includeRegistrationCount));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/DispatchApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/DispatchApi.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchApi {
   private ApiClient apiClient;
 
@@ -784,11 +783,12 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to dispatch_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return DispatchListSchema
    * @throws ApiException if fails to make API call
    */
-  public DispatchListSchema getDestinationDispatches(String destinationId, String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getDestinationDispatchesWithHttpInfo(destinationId, courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public DispatchListSchema getDestinationDispatches(String destinationId, String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getDestinationDispatchesWithHttpInfo(destinationId, courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -804,10 +804,11 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to dispatch_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;DispatchListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<DispatchListSchema> getDestinationDispatchesWithHttpInfo(String destinationId, String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<DispatchListSchema> getDestinationDispatchesWithHttpInfo(String destinationId, String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // verify the required parameter 'destinationId' is set
@@ -833,6 +834,7 @@ public class DispatchApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -969,11 +971,12 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to destination_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return DestinationListSchema
    * @throws ApiException if fails to make API call
    */
-  public DestinationListSchema getDestinations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getDestinationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public DestinationListSchema getDestinations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getDestinationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -988,10 +991,11 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to destination_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;DestinationListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<DestinationListSchema> getDestinationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<DestinationListSchema> getDestinationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -1011,6 +1015,7 @@ public class DispatchApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -1365,11 +1370,12 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to dispatch_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return DispatchListSchema
    * @throws ApiException if fails to make API call
    */
-  public DispatchListSchema getDispatches(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getDispatchesWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public DispatchListSchema getDispatches(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getDispatchesWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -1384,10 +1390,11 @@ public class DispatchApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to dispatch_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;DispatchListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<DispatchListSchema> getDispatchesWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<DispatchListSchema> getDispatchesWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -1407,6 +1414,7 @@ public class DispatchApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -1594,7 +1602,7 @@ public class DispatchApi {
     };
     final String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
 
-    String[] localVarAuthNames = new String[] { "UNSECURED" };
+    String[] localVarAuthNames = new String[] {  };
 
 
     return apiClient.invokeAPI(localVarPath, "GET", localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, null);

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/InvitationsApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/InvitationsApi.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class InvitationsApi {
   private ApiClient apiClient;
 
@@ -225,11 +224,12 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return InvitationSummaryList
    * @throws ApiException if fails to make API call
    */
-  public InvitationSummaryList getAllInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getAllInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public InvitationSummaryList getAllInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getAllInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -244,10 +244,11 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;InvitationSummaryList&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<InvitationSummaryList> getAllInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<InvitationSummaryList> getAllInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -267,6 +268,7 @@ public class InvitationsApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -459,11 +461,12 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return PrivateInvitationList
    * @throws ApiException if fails to make API call
    */
-  public PrivateInvitationList getPrivateInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getPrivateInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public PrivateInvitationList getPrivateInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getPrivateInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -478,10 +481,11 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;PrivateInvitationList&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<PrivateInvitationList> getPrivateInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<PrivateInvitationList> getPrivateInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -501,6 +505,7 @@ public class InvitationsApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -531,11 +536,12 @@ public class InvitationsApi {
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeRegistrationReport Optional flag to include basic registration information (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return UserInvitationList
    * @throws ApiException if fails to make API call
    */
-  public UserInvitationList getPrivateUserInvitations(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport) throws ApiException {
-    return getPrivateUserInvitationsWithHttpInfo(invitationId, since, until, datetimeFilter, filter, filterBy, orderBy, more, includeRegistrationReport).getData();
+  public UserInvitationList getPrivateUserInvitations(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport, Boolean includeTotalCount) throws ApiException {
+    return getPrivateUserInvitationsWithHttpInfo(invitationId, since, until, datetimeFilter, filter, filterBy, orderBy, more, includeRegistrationReport, includeTotalCount).getData();
       }
 
   /**
@@ -550,10 +556,11 @@ public class InvitationsApi {
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeRegistrationReport Optional flag to include basic registration information (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;UserInvitationList&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<UserInvitationList> getPrivateUserInvitationsWithHttpInfo(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport) throws ApiException {
+  public ApiResponse<UserInvitationList> getPrivateUserInvitationsWithHttpInfo(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // verify the required parameter 'invitationId' is set
@@ -578,6 +585,7 @@ public class InvitationsApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeRegistrationReport", includeRegistrationReport));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -664,11 +672,12 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return PublicInvitationList
    * @throws ApiException if fails to make API call
    */
-  public PublicInvitationList getPublicInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getPublicInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more).getData();
+  public PublicInvitationList getPublicInvitations(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getPublicInvitationsWithHttpInfo(courseId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -683,10 +692,11 @@ public class InvitationsApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to invitation_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;PublicInvitationList&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<PublicInvitationList> getPublicInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<PublicInvitationList> getPublicInvitationsWithHttpInfo(String courseId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -706,6 +716,7 @@ public class InvitationsApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     
@@ -736,11 +747,12 @@ public class InvitationsApi {
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeRegistrationReport Optional flag to include basic registration information (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return UserInvitationList
    * @throws ApiException if fails to make API call
    */
-  public UserInvitationList getPublicUserInvitations(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport) throws ApiException {
-    return getPublicUserInvitationsWithHttpInfo(invitationId, since, until, datetimeFilter, filter, filterBy, orderBy, more, includeRegistrationReport).getData();
+  public UserInvitationList getPublicUserInvitations(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport, Boolean includeTotalCount) throws ApiException {
+    return getPublicUserInvitationsWithHttpInfo(invitationId, since, until, datetimeFilter, filter, filterBy, orderBy, more, includeRegistrationReport, includeTotalCount).getData();
       }
 
   /**
@@ -755,10 +767,11 @@ public class InvitationsApi {
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
    * @param includeRegistrationReport Optional flag to include basic registration information (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;UserInvitationList&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<UserInvitationList> getPublicUserInvitationsWithHttpInfo(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport) throws ApiException {
+  public ApiResponse<UserInvitationList> getPublicUserInvitationsWithHttpInfo(String invitationId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeRegistrationReport, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // verify the required parameter 'invitationId' is set
@@ -783,6 +796,7 @@ public class InvitationsApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeRegistrationReport", includeRegistrationReport));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/LearnerApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/LearnerApi.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LearnerApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/PingApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/PingApi.java
@@ -15,7 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PingApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/RegistrationApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/RegistrationApi.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class RegistrationApi {
   private ApiClient apiClient;
 
@@ -1313,11 +1312,12 @@ public class RegistrationApi {
    * @param includeChildResults Include information about each learning object, not just the top level in the results (optional, default to false)
    * @param includeInteractionsAndObjectives Include interactions and objectives in the results (optional, default to false)
    * @param includeRuntime Include runtime details in the results (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return RegistrationListSchema
    * @throws ApiException if fails to make API call
    */
-  public RegistrationListSchema getRegistrations(String courseId, String learnerId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeChildResults, Boolean includeInteractionsAndObjectives, Boolean includeRuntime) throws ApiException {
-    return getRegistrationsWithHttpInfo(courseId, learnerId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeChildResults, includeInteractionsAndObjectives, includeRuntime).getData();
+  public RegistrationListSchema getRegistrations(String courseId, String learnerId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeChildResults, Boolean includeInteractionsAndObjectives, Boolean includeRuntime, Boolean includeTotalCount) throws ApiException {
+    return getRegistrationsWithHttpInfo(courseId, learnerId, since, until, datetimeFilter, tags, filter, filterBy, orderBy, more, includeChildResults, includeInteractionsAndObjectives, includeRuntime, includeTotalCount).getData();
       }
 
   /**
@@ -1336,10 +1336,11 @@ public class RegistrationApi {
    * @param includeChildResults Include information about each learning object, not just the top level in the results (optional, default to false)
    * @param includeInteractionsAndObjectives Include interactions and objectives in the results (optional, default to false)
    * @param includeRuntime Include runtime details in the results (optional, default to false)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;RegistrationListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<RegistrationListSchema> getRegistrationsWithHttpInfo(String courseId, String learnerId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeChildResults, Boolean includeInteractionsAndObjectives, Boolean includeRuntime) throws ApiException {
+  public ApiResponse<RegistrationListSchema> getRegistrationsWithHttpInfo(String courseId, String learnerId, OffsetDateTime since, OffsetDateTime until, String datetimeFilter, List<String> tags, String filter, String filterBy, String orderBy, String more, Boolean includeChildResults, Boolean includeInteractionsAndObjectives, Boolean includeRuntime, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -1363,6 +1364,7 @@ public class RegistrationApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeChildResults", includeChildResults));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeInteractionsAndObjectives", includeInteractionsAndObjectives));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeRuntime", includeRuntime));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/ReportingApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/ReportingApi.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ReportingApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/XapiApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/XapiApi.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiApi {
   private ApiClient apiClient;
 
@@ -413,11 +412,12 @@ public class XapiApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to credential_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return XapiCredentialsListSchema
    * @throws ApiException if fails to make API call
    */
-  public XapiCredentialsListSchema getXapiCredentials(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more) throws ApiException {
-    return getXapiCredentialsWithHttpInfo(since, until, datetimeFilter, filter, filterBy, orderBy, more).getData();
+  public XapiCredentialsListSchema getXapiCredentials(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
+    return getXapiCredentialsWithHttpInfo(since, until, datetimeFilter, filter, filterBy, orderBy, more, includeTotalCount).getData();
       }
 
   /**
@@ -430,10 +430,11 @@ public class XapiApi {
    * @param filterBy Optional enum parameter for specifying the field on which to run the filter.  (optional, default to credential_id)
    * @param orderBy Optional enum parameter for specifying the field and order by which to sort the results.  (optional, default to updated_asc)
    * @param more Pagination token returned as &#x60;more&#x60; property of multi page list requests (optional)
+   * @param includeTotalCount Include the total count of results matching the provided filters as a header on the initial request.  The header will not be present on subsequent requests resulting from passing the &#x60;more&#x60; token.  (optional, default to false)
    * @return ApiResponse&lt;XapiCredentialsListSchema&gt;
    * @throws ApiException if fails to make API call
    */
-  public ApiResponse<XapiCredentialsListSchema> getXapiCredentialsWithHttpInfo(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more) throws ApiException {
+  public ApiResponse<XapiCredentialsListSchema> getXapiCredentialsWithHttpInfo(OffsetDateTime since, OffsetDateTime until, String datetimeFilter, String filter, String filterBy, String orderBy, String more, Boolean includeTotalCount) throws ApiException {
     Object localVarPostBody = null;
     
     // create path and map variables
@@ -451,6 +452,7 @@ public class XapiApi {
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "filterBy", filterBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "orderBy", orderBy));
     localVarQueryParams.addAll(apiClient.parameterToPairs("", "more", more));
+    localVarQueryParams.addAll(apiClient.parameterToPairs("", "includeTotalCount", includeTotalCount));
 
     
     

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/api/ZoomiApi.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/api/ZoomiApi.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ZoomiApi {
   private ApiClient apiClient;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/auth/ApiKeyAuth.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/auth/ApiKeyAuth.java
@@ -18,7 +18,6 @@ import com.rusticisoftware.cloud.v2.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApiKeyAuth implements Authentication {
   private final String location;
   private final String paramName;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/auth/HttpBasicAuth.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/auth/HttpBasicAuth.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class HttpBasicAuth implements Authentication {
   private String username;
   private String password;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/auth/OAuth.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/auth/OAuth.java
@@ -18,7 +18,6 @@ import com.rusticisoftware.cloud.v2.client.Pair;
 import java.util.Map;
 import java.util.List;
 
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class OAuth implements Authentication {
   private String accessToken;
 

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/AboutSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/AboutSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * AboutSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class AboutSchema {
   @JsonProperty("version")
   private String version = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ActivityResultSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ActivityResultSchema.java
@@ -32,7 +32,6 @@ import java.util.List;
 /**
  * ActivityResultSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ActivityResultSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationInfoListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationInfoListSchema.java
@@ -18,46 +18,49 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.rusticisoftware.cloud.v2.client.model.RegistrationSchema;
+import com.rusticisoftware.cloud.v2.client.model.ApplicationInfoSchema;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
- * RegistrationListSchema
+ * ApplicationInfoListSchema
  */
-public class RegistrationListSchema {
-  @JsonProperty("registrations")
-  private List<RegistrationSchema> registrations = new ArrayList<>();
+public class ApplicationInfoListSchema {
+  @JsonProperty("applications")
+  private List<ApplicationInfoSchema> applications = null;
 
   @JsonProperty("more")
   private String more = null;
 
-  public RegistrationListSchema registrations(List<RegistrationSchema> registrations) {
-    this.registrations = registrations;
+  public ApplicationInfoListSchema applications(List<ApplicationInfoSchema> applications) {
+    this.applications = applications;
     return this;
   }
 
-  public RegistrationListSchema addRegistrationsItem(RegistrationSchema registrationsItem) {
-    this.registrations.add(registrationsItem);
+  public ApplicationInfoListSchema addApplicationsItem(ApplicationInfoSchema applicationsItem) {
+    if (this.applications == null) {
+      this.applications = new ArrayList<>();
+    }
+    this.applications.add(applicationsItem);
     return this;
   }
 
   /**
-   * Get registrations
-   * @return registrations
+   * Get applications
+   * @return applications
   **/
-  @ApiModelProperty(required = true, value = "")
-  public List<RegistrationSchema> getRegistrations() {
-    return registrations;
+  @ApiModelProperty(value = "")
+  public List<ApplicationInfoSchema> getApplications() {
+    return applications;
   }
 
-  public void setRegistrations(List<RegistrationSchema> registrations) {
-    this.registrations = registrations;
+  public void setApplications(List<ApplicationInfoSchema> applications) {
+    this.applications = applications;
   }
 
-  public RegistrationListSchema more(String more) {
+  public ApplicationInfoListSchema more(String more) {
     this.more = more;
     return this;
   }
@@ -84,22 +87,22 @@ public class RegistrationListSchema {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    RegistrationListSchema registrationListSchema = (RegistrationListSchema) o;
-    return Objects.equals(this.registrations, registrationListSchema.registrations) &&
-        Objects.equals(this.more, registrationListSchema.more);
+    ApplicationInfoListSchema applicationInfoListSchema = (ApplicationInfoListSchema) o;
+    return Objects.equals(this.applications, applicationInfoListSchema.applications) &&
+        Objects.equals(this.more, applicationInfoListSchema.more);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(registrations, more);
+    return Objects.hash(applications, more);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class RegistrationListSchema {\n");
+    sb.append("class ApplicationInfoListSchema {\n");
     
-    sb.append("    registrations: ").append(toIndentedString(registrations)).append("\n");
+    sb.append("    applications: ").append(toIndentedString(applications)).append("\n");
     sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationInfoSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationInfoSchema.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 /**
  * ApplicationInfoSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationInfoSchema {
   @JsonProperty("id")
   private String id = null;
@@ -35,6 +34,9 @@ public class ApplicationInfoSchema {
 
   @JsonProperty("createDate")
   private OffsetDateTime createDate = null;
+
+  @JsonProperty("updateDate")
+  private OffsetDateTime updateDate = null;
 
   @JsonProperty("allowDelete")
   private Boolean allowDelete = null;
@@ -97,6 +99,24 @@ public class ApplicationInfoSchema {
 
   public void setCreateDate(OffsetDateTime createDate) {
     this.createDate = createDate;
+  }
+
+  public ApplicationInfoSchema updateDate(OffsetDateTime updateDate) {
+    this.updateDate = updateDate;
+    return this;
+  }
+
+  /**
+   * The time the application was last updated in UTC
+   * @return updateDate
+  **/
+  @ApiModelProperty(value = "The time the application was last updated in UTC")
+  public OffsetDateTime getUpdateDate() {
+    return updateDate;
+  }
+
+  public void setUpdateDate(OffsetDateTime updateDate) {
+    this.updateDate = updateDate;
   }
 
   public ApplicationInfoSchema allowDelete(Boolean allowDelete) {
@@ -166,6 +186,7 @@ public class ApplicationInfoSchema {
     return Objects.equals(this.id, applicationInfoSchema.id) &&
         Objects.equals(this.name, applicationInfoSchema.name) &&
         Objects.equals(this.createDate, applicationInfoSchema.createDate) &&
+        Objects.equals(this.updateDate, applicationInfoSchema.updateDate) &&
         Objects.equals(this.allowDelete, applicationInfoSchema.allowDelete) &&
         Objects.equals(this.courseCount, applicationInfoSchema.courseCount) &&
         Objects.equals(this.registrationCount, applicationInfoSchema.registrationCount);
@@ -173,7 +194,7 @@ public class ApplicationInfoSchema {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, createDate, allowDelete, courseCount, registrationCount);
+    return Objects.hash(id, name, createDate, updateDate, allowDelete, courseCount, registrationCount);
   }
 
   @Override
@@ -184,6 +205,7 @@ public class ApplicationInfoSchema {
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    createDate: ").append(toIndentedString(createDate)).append("\n");
+    sb.append("    updateDate: ").append(toIndentedString(updateDate)).append("\n");
     sb.append("    allowDelete: ").append(toIndentedString(allowDelete)).append("\n");
     sb.append("    courseCount: ").append(toIndentedString(courseCount)).append("\n");
     sb.append("    registrationCount: ").append(toIndentedString(registrationCount)).append("\n");

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * ApplicationListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationListSchema {
   @JsonProperty("applications")
   private List<ApplicationSchema> applications = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationRequestSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ApplicationRequestSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationRequestSchema {
   @JsonProperty("name")
   private String name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ApplicationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationToken.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ApplicationToken.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ApplicationToken
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ApplicationToken {
   @JsonProperty("access_token")
   private String accessToken = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/AssetFileSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/AssetFileSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * AssetFileSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class AssetFileSchema {
   @JsonProperty("filename")
   private String filename = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/BatchTagsSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/BatchTagsSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * BatchTagsSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class BatchTagsSchema {
   @JsonProperty("ids")
   private List<String> ids = new ArrayList<>();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CommentSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CommentSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CommentSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CommentSchema {
   @JsonProperty("value")
   private String value = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CompletionAmountSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CompletionAmountSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CompletionAmountSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CompletionAmountSchema {
   @JsonProperty("scaled")
   private Double scaled = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ConnectorListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ConnectorListSchema.java
@@ -28,7 +28,6 @@ import java.util.List;
  * List of content connectors.
  */
 @ApiModel(description = "List of content connectors.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ConnectorListSchema {
   @JsonProperty("connectorEntries")
   private List<ConnectorSchema> connectorEntries = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ConnectorSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ConnectorSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * A content connector.
  */
 @ApiModel(description = "A content connector.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ConnectorSchema {
   @JsonProperty("connectorId")
   private String connectorId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseActivitySchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseActivitySchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * CourseActivitySchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseActivitySchema {
   @JsonProperty("externalIdentifier")
   private String externalIdentifier = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseListNonPagedSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseListNonPagedSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * CourseListNonPagedSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseListNonPagedSchema {
   @JsonProperty("courses")
   private List<CourseSchema> courses = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * CourseListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseListSchema {
   @JsonProperty("courses")
   private List<CourseSchema> courses = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseReferenceSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseReferenceSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Basic information about a course for when a course is referenced by other objects, such as a registration.
  */
 @ApiModel(description = "Basic information about a course for when a course is referenced by other objects, such as a registration.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseReferenceSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CourseSchema.java
@@ -29,7 +29,6 @@ import java.util.List;
 /**
  * CourseSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CourseSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateConnectorSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateConnectorSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CreateConnectorSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreateConnectorSchema {
   @JsonProperty("contentConnectorType")
   private String contentConnectorType = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchIdSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchIdSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CreateDispatchIdSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreateDispatchIdSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * CreateDispatchListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreateDispatchListSchema {
   @JsonProperty("dispatches")
   private List<CreateDispatchIdSchema> dispatches = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateDispatchSchema.java
@@ -28,7 +28,6 @@ import java.util.List;
 /**
  * CreateDispatchSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreateDispatchSchema {
   @JsonProperty("destinationId")
   private String destinationId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreatePrivateInvitationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreatePrivateInvitationSchema.java
@@ -29,7 +29,6 @@ import java.util.List;
 /**
  * CreatePrivateInvitationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreatePrivateInvitationSchema {
   @JsonProperty("courseId")
   private String courseId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreatePublicInvitationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreatePublicInvitationSchema.java
@@ -28,7 +28,6 @@ import java.util.List;
 /**
  * CreatePublicInvitationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreatePublicInvitationSchema {
   @JsonProperty("courseId")
   private String courseId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateRegistrationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CreateRegistrationSchema.java
@@ -30,7 +30,6 @@ import java.util.List;
 /**
  * CreateRegistrationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CreateRegistrationSchema {
   @JsonProperty("courseId")
   private String courseId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialCreatedSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialCreatedSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CredentialCreatedSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CredentialCreatedSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * CredentialListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CredentialListSchema {
   @JsonProperty("credentials")
   private List<CredentialSchema> credentials = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialRequestSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CredentialRequestSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CredentialRequestSchema {
   @JsonProperty("name")
   private String name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/CredentialSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * CredentialSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class CredentialSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationIdSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationIdSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * DestinationIdSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DestinationIdSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * DestinationListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DestinationListSchema {
   @JsonProperty("destinations")
   private List<DestinationIdSchema> destinations = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DestinationSchema.java
@@ -29,7 +29,6 @@ import java.util.List;
 /**
  * DestinationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DestinationSchema {
   @JsonProperty("name")
   private String name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchIdSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchIdSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * DispatchIdSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchIdSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * DispatchListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchListSchema {
   @JsonProperty("dispatches")
   private List<DispatchIdSchema> dispatches = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchLti13InfoSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchLti13InfoSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * DispatchLti13InfoSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchLti13InfoSchema {
   @JsonProperty("targetLinkUri")
   private String targetLinkUri = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchLtiInfoSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchLtiInfoSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * DispatchLtiInfoSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchLtiInfoSchema {
   @JsonProperty("url")
   private String url = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchRegistrationCountSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchRegistrationCountSchema.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 /**
  * DispatchRegistrationCountSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchRegistrationCountSchema {
   @JsonProperty("registrationCount")
   private Integer registrationCount = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/DispatchSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * DispatchSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class DispatchSchema {
   @JsonProperty("destinationId")
   private String destinationId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/FileListItemSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/FileListItemSchema.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 /**
  * FileListItemSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class FileListItemSchema {
   @JsonProperty("path")
   private String path = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/FileListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/FileListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * FileListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class FileListSchema {
   @JsonProperty("files")
   private List<FileListItemSchema> files = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportAssetRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportAssetRequestSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Request schema to import a course asset file by fetching it from a url 
  */
 @ApiModel(description = "Request schema to import a course asset file by fetching it from a url ")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportAssetRequestSchema {
   @JsonProperty("fetchUrl")
   private String fetchUrl = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportConnectorRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportConnectorRequestSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Used to create a course from a content connector. Before creating a course using this schema, a content connector must be created using the &#x60;/contentConnectors&#x60; API endpoints. Once a content connector has been created, this schema can be used to create a course that can be launched using that connector.  For example, this schema is used to import an LTI 1.3 Tool to be consumed by SCORM Cloud acting as the LTI Platform. 
  */
 @ApiModel(description = "Used to create a course from a content connector. Before creating a course using this schema, a content connector must be created using the `/contentConnectors` API endpoints. Once a content connector has been created, this schema can be used to create a course that can be launched using that connector.  For example, this schema is used to import an LTI 1.3 Tool to be consumed by SCORM Cloud acting as the LTI Platform. ")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportConnectorRequestSchema {
   @JsonProperty("connectorId")
   private String connectorId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportFetchRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportFetchRequestSchema.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Request to import a course by downloading it from a url
  */
 @ApiModel(description = "Request to import a course by downloading it from a url")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportFetchRequestSchema {
   @JsonProperty("url")
   private String url = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportJobResultSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportJobResultSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ImportJobResultSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportJobResultSchema {
   @JsonProperty("jobId")
   private String jobId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportMediaFileReferenceRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportMediaFileReferenceRequestSchema.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Used to create a course that references a media file. Upon import, the actual file is not downloaded and stored on SCORM Cloud&#39;s servers. Instead, the media file wrapper will load the content from the provided URL. 
  */
 @ApiModel(description = "Used to create a course that references a media file. Upon import, the actual file is not downloaded and stored on SCORM Cloud's servers. Instead, the media file wrapper will load the content from the provided URL. ")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportMediaFileReferenceRequestSchema {
   @JsonProperty("url")
   private String url = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportRequestSchema.java
@@ -28,7 +28,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Request to import a new course. Exactly one of the schemas must be supplied, depending on the desired import behavior. 
  */
 @ApiModel(description = "Request to import a new course. Exactly one of the schemas must be supplied, depending on the desired import behavior. ")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportRequestSchema {
   @JsonProperty("fetchRequest")
   private ImportFetchRequestSchema fetchRequest = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportResultSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ImportResultSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * ImportResultSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ImportResultSchema {
   @JsonProperty("webPathToCourse")
   private String webPathToCourse = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/IntegerResultSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/IntegerResultSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * IntegerResultSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class IntegerResultSchema {
   @JsonProperty("result")
   private Integer result = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationEmailSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationEmailSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
  * Object representing an e-mail to be sent to a given list of e-mail addresses inviting them to participate in a course.
  */
 @ApiModel(description = "Object representing an e-mail to be sent to a given list of e-mail addresses inviting them to participate in a course.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class InvitationEmailSchema {
   @JsonProperty("subject")
   private String subject = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationJobStatusSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationJobStatusSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * InvitationJobStatusSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class InvitationJobStatusSchema {
   /**
    * The status of the job.

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationSummaryList.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationSummaryList.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.rusticisoftware.cloud.v2.client.model.InvitationSummarySchema;
+import com.rusticisoftware.cloud.v2.client.model.PaginatedList;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.ArrayList;
@@ -27,13 +28,9 @@ import java.util.List;
 /**
  * InvitationSummaryList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
-public class InvitationSummaryList {
+public class InvitationSummaryList extends PaginatedList {
   @JsonProperty("invitations")
   private List<InvitationSummarySchema> invitations = null;
-
-  @JsonProperty("more")
-  private String more = null;
 
   public InvitationSummaryList invitations(List<InvitationSummarySchema> invitations) {
     this.invitations = invitations;
@@ -61,24 +58,6 @@ public class InvitationSummaryList {
     this.invitations = invitations;
   }
 
-  public InvitationSummaryList more(String more) {
-    this.more = more;
-    return this;
-  }
-
-  /**
-   * Token for getting the next set of results, from the prior set of results.
-   * @return more
-  **/
-  @ApiModelProperty(value = "Token for getting the next set of results, from the prior set of results.")
-  public String getMore() {
-    return more;
-  }
-
-  public void setMore(String more) {
-    this.more = more;
-  }
-
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -90,21 +69,20 @@ public class InvitationSummaryList {
     }
     InvitationSummaryList invitationSummaryList = (InvitationSummaryList) o;
     return Objects.equals(this.invitations, invitationSummaryList.invitations) &&
-        Objects.equals(this.more, invitationSummaryList.more);
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invitations, more);
+    return Objects.hash(invitations, super.hashCode());
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class InvitationSummaryList {\n");
-    
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    invitations: ").append(toIndentedString(invitations)).append("\n");
-    sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationSummarySchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/InvitationSummarySchema.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 /**
  * InvitationSummarySchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class InvitationSummarySchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ItemValuePairSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ItemValuePairSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ItemValuePairSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ItemValuePairSchema {
   @JsonProperty("item")
   private String item = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchAuthOptionsSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchAuthOptionsSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * LaunchAuthOptionsSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchAuthOptionsSchema {
   @JsonProperty("ipAddress")
   private Boolean ipAddress = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchAuthSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchAuthSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * LaunchAuthSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchAuthSchema {
   /**
    * Gets or Sets type

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchHistoryListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchHistoryListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * LaunchHistoryListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchHistoryListSchema {
   @JsonProperty("launchHistory")
   private List<LaunchHistorySchema> launchHistory = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchHistorySchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchHistorySchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * LaunchHistorySchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchHistorySchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchLinkRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchLinkRequestSchema.java
@@ -28,7 +28,6 @@ import java.util.List;
 /**
  * LaunchLinkRequestSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchLinkRequestSchema {
   @JsonProperty("expiry")
   private Integer expiry = 120;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchLinkSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LaunchLinkSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * LaunchLinkSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LaunchLinkSchema {
   @JsonProperty("launchLink")
   private String launchLink = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LearnerPreferenceSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LearnerPreferenceSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * LearnerPreferenceSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LearnerPreferenceSchema {
   @JsonProperty("audioLevel")
   private Double audioLevel = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/LearnerSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/LearnerSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * LearnerSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class LearnerSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/Lti13PlatformConfigurationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/Lti13PlatformConfigurationSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Lti13PlatformConfigurationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class Lti13PlatformConfigurationSchema {
   @JsonProperty("clientId")
   private String clientId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/Lti13ToolConfigurationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/Lti13ToolConfigurationSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * Lti13ToolConfigurationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class Lti13ToolConfigurationSchema {
   @JsonProperty("publicKey")
   private String publicKey = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/MediaFileMetadataSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/MediaFileMetadataSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * Metadata used to set various properties of a media file course 
  */
 @ApiModel(description = "Metadata used to set various properties of a media file course ")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class MediaFileMetadataSchema {
   @JsonProperty("title")
   private String title = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/MessageSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/MessageSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * MessageSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class MessageSchema {
   @JsonProperty("message")
   private String message = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/MetadataSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/MetadataSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * MetadataSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class MetadataSchema {
   @JsonProperty("title")
   private String title = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ObjectiveSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ObjectiveSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ObjectiveSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ObjectiveSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PaginatedList.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PaginatedList.java
@@ -22,28 +22,28 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
 /**
- * EnabledSchema
+ * PaginatedList
  */
-public class EnabledSchema {
-  @JsonProperty("enabled")
-  private Boolean enabled = null;
+public class PaginatedList {
+  @JsonProperty("more")
+  private String more = null;
 
-  public EnabledSchema enabled(Boolean enabled) {
-    this.enabled = enabled;
+  public PaginatedList more(String more) {
+    this.more = more;
     return this;
   }
 
   /**
-   * Get enabled
-   * @return enabled
+   * Token for getting the next set of results, from the prior set of results.
+   * @return more
   **/
-  @ApiModelProperty(value = "")
-  public Boolean isEnabled() {
-    return enabled;
+  @ApiModelProperty(value = "Token for getting the next set of results, from the prior set of results.")
+  public String getMore() {
+    return more;
   }
 
-  public void setEnabled(Boolean enabled) {
-    this.enabled = enabled;
+  public void setMore(String more) {
+    this.more = more;
   }
 
 
@@ -55,21 +55,21 @@ public class EnabledSchema {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    EnabledSchema enabledSchema = (EnabledSchema) o;
-    return Objects.equals(this.enabled, enabledSchema.enabled);
+    PaginatedList paginatedList = (PaginatedList) o;
+    return Objects.equals(this.more, paginatedList.more);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(enabled);
+    return Objects.hash(more);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
-    sb.append("class EnabledSchema {\n");
+    sb.append("class PaginatedList {\n");
     
-    sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
+    sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PermissionsSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PermissionsSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * PermissionsSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PermissionsSchema {
   @JsonProperty("scopes")
   private List<String> scopes = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PingSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PingSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * PingSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PingSchema {
   @JsonProperty("apiMessage")
   private String apiMessage = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PostBackSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PostBackSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * PostBackSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PostBackSchema {
   @JsonProperty("url")
   private String url = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationList.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationList.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.rusticisoftware.cloud.v2.client.model.PaginatedList;
 import com.rusticisoftware.cloud.v2.client.model.PrivateInvitationSchema;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,13 +28,9 @@ import java.util.List;
 /**
  * PrivateInvitationList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
-public class PrivateInvitationList {
+public class PrivateInvitationList extends PaginatedList {
   @JsonProperty("invitations")
   private List<PrivateInvitationSchema> invitations = null;
-
-  @JsonProperty("more")
-  private String more = null;
 
   public PrivateInvitationList invitations(List<PrivateInvitationSchema> invitations) {
     this.invitations = invitations;
@@ -61,24 +58,6 @@ public class PrivateInvitationList {
     this.invitations = invitations;
   }
 
-  public PrivateInvitationList more(String more) {
-    this.more = more;
-    return this;
-  }
-
-  /**
-   * Token for getting the next set of results, from the prior set of results.
-   * @return more
-  **/
-  @ApiModelProperty(value = "Token for getting the next set of results, from the prior set of results.")
-  public String getMore() {
-    return more;
-  }
-
-  public void setMore(String more) {
-    this.more = more;
-  }
-
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -90,21 +69,20 @@ public class PrivateInvitationList {
     }
     PrivateInvitationList privateInvitationList = (PrivateInvitationList) o;
     return Objects.equals(this.invitations, privateInvitationList.invitations) &&
-        Objects.equals(this.more, privateInvitationList.more);
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invitations, more);
+    return Objects.hash(invitations, super.hashCode());
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class PrivateInvitationList {\n");
-    
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    invitations: ").append(toIndentedString(invitations)).append("\n");
-    sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationSchema.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 /**
  * PrivateInvitationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PrivateInvitationSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationUpdateSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PrivateInvitationUpdateSchema.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 /**
  * PrivateInvitationUpdateSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PrivateInvitationUpdateSchema {
   @JsonProperty("allowLaunch")
   private Boolean allowLaunch = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationList.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationList.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.rusticisoftware.cloud.v2.client.model.PaginatedList;
 import com.rusticisoftware.cloud.v2.client.model.PublicInvitationSchema;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,13 +28,9 @@ import java.util.List;
 /**
  * PublicInvitationList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
-public class PublicInvitationList {
+public class PublicInvitationList extends PaginatedList {
   @JsonProperty("invitations")
   private List<PublicInvitationSchema> invitations = null;
-
-  @JsonProperty("more")
-  private String more = null;
 
   public PublicInvitationList invitations(List<PublicInvitationSchema> invitations) {
     this.invitations = invitations;
@@ -61,24 +58,6 @@ public class PublicInvitationList {
     this.invitations = invitations;
   }
 
-  public PublicInvitationList more(String more) {
-    this.more = more;
-    return this;
-  }
-
-  /**
-   * Token for getting the next set of results, from the prior set of results.
-   * @return more
-  **/
-  @ApiModelProperty(value = "Token for getting the next set of results, from the prior set of results.")
-  public String getMore() {
-    return more;
-  }
-
-  public void setMore(String more) {
-    this.more = more;
-  }
-
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -90,21 +69,20 @@ public class PublicInvitationList {
     }
     PublicInvitationList publicInvitationList = (PublicInvitationList) o;
     return Objects.equals(this.invitations, publicInvitationList.invitations) &&
-        Objects.equals(this.more, publicInvitationList.more);
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(invitations, more);
+    return Objects.hash(invitations, super.hashCode());
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class PublicInvitationList {\n");
-    
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    invitations: ").append(toIndentedString(invitations)).append("\n");
-    sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationSchema.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 /**
  * PublicInvitationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PublicInvitationSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationUpdateSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/PublicInvitationUpdateSchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * PublicInvitationUpdateSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class PublicInvitationUpdateSchema {
   @JsonProperty("allowLaunch")
   private Boolean allowLaunch = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/RegistrationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/RegistrationSchema.java
@@ -35,7 +35,6 @@ import java.util.List;
 /**
  * RegistrationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class RegistrationSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAccountInfoSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAccountInfoSchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * ReportageAccountInfoSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ReportageAccountInfoSchema {
   @JsonProperty("email")
   private String email = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAccountInfoUsageSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAccountInfoUsageSchema.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 /**
  * ReportageAccountInfoUsageSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ReportageAccountInfoUsageSchema {
   @JsonProperty("monthStart")
   private OffsetDateTime monthStart = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAuthTokenSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageAuthTokenSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ReportageAuthTokenSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ReportageAuthTokenSchema {
   @JsonProperty("authEnabled")
   private Boolean authEnabled = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageLinkSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ReportageLinkSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ReportageLinkSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ReportageLinkSchema {
   @JsonProperty("reportageLink")
   private String reportageLink = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ResponseError.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ResponseError.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ResponseError
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ResponseError {
   @JsonProperty("message")
   private String message = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeInteractionSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeInteractionSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * RuntimeInteractionSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class RuntimeInteractionSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeObjectiveSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeObjectiveSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * RuntimeObjectiveSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class RuntimeObjectiveSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/RuntimeSchema.java
@@ -30,7 +30,6 @@ import java.util.List;
 /**
  * RuntimeSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class RuntimeSchema {
   @JsonProperty("completionStatus")
   private String completionStatus = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ScoreSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ScoreSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ScoreSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ScoreSchema {
   @JsonProperty("scaled")
   private Double scaled = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingItem.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingItem.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SettingItem
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingItem {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * SettingListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingListSchema {
   @JsonProperty("settingItems")
   private List<SettingItem> settingItems = new ArrayList<>();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingMetadata.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingMetadata.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * SettingMetadata
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingMetadata {
   @JsonProperty("default")
   private String _default = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingValidValue.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingValidValue.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SettingValidValue
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingValidValue {
   @JsonProperty("value")
   private String value = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingsIndividualSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingsIndividualSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SettingsIndividualSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingsIndividualSchema {
   @JsonProperty("settingId")
   private String settingId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingsPostSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SettingsPostSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * SettingsPostSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SettingsPostSchema {
   @JsonProperty("settings")
   private List<SettingsIndividualSchema> settings = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/SharedDataEntrySchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/SharedDataEntrySchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * SharedDataEntrySchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class SharedDataEntrySchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/StaticPropertiesSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/StaticPropertiesSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * StaticPropertiesSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class StaticPropertiesSchema {
   @JsonProperty("completionThreshold")
   private String completionThreshold = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/StringResultSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/StringResultSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * StringResultSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class StringResultSchema {
   @JsonProperty("result")
   private String result = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/TagListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/TagListSchema.java
@@ -26,7 +26,6 @@ import java.util.List;
 /**
  * TagListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class TagListSchema {
   @JsonProperty("tags")
   private List<String> tags = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/TitleSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/TitleSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * TitleSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class TitleSchema {
   @JsonProperty("title")
   private String title = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/TokenRequestSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/TokenRequestSchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * TokenRequestSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class TokenRequestSchema {
   @JsonProperty("permissions")
   private PermissionsSchema permissions = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateApplicationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateApplicationSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * UpdateApplicationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class UpdateApplicationSchema {
   @JsonProperty("name")
   private String name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateConnectorSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateConnectorSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * UpdateConnectorSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class UpdateConnectorSchema {
   @JsonProperty("configuration")
   private Object _configuration = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateDispatchSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UpdateDispatchSchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * UpdateDispatchSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class UpdateDispatchSchema {
   @JsonProperty("allowNewRegistrations")
   private Boolean allowNewRegistrations = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationList.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationList.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.rusticisoftware.cloud.v2.client.model.PaginatedList;
 import com.rusticisoftware.cloud.v2.client.model.UserInvitationSchema;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -27,13 +28,9 @@ import java.util.List;
 /**
  * UserInvitationList
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
-public class UserInvitationList {
+public class UserInvitationList extends PaginatedList {
   @JsonProperty("userInvitations")
   private List<UserInvitationSchema> userInvitations = null;
-
-  @JsonProperty("more")
-  private String more = null;
 
   public UserInvitationList userInvitations(List<UserInvitationSchema> userInvitations) {
     this.userInvitations = userInvitations;
@@ -61,24 +58,6 @@ public class UserInvitationList {
     this.userInvitations = userInvitations;
   }
 
-  public UserInvitationList more(String more) {
-    this.more = more;
-    return this;
-  }
-
-  /**
-   * Token for getting the next set of results, from the prior set of results.
-   * @return more
-  **/
-  @ApiModelProperty(value = "Token for getting the next set of results, from the prior set of results.")
-  public String getMore() {
-    return more;
-  }
-
-  public void setMore(String more) {
-    this.more = more;
-  }
-
 
   @Override
   public boolean equals(java.lang.Object o) {
@@ -90,21 +69,20 @@ public class UserInvitationList {
     }
     UserInvitationList userInvitationList = (UserInvitationList) o;
     return Objects.equals(this.userInvitations, userInvitationList.userInvitations) &&
-        Objects.equals(this.more, userInvitationList.more);
+        super.equals(o);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userInvitations, more);
+    return Objects.hash(userInvitations, super.hashCode());
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class UserInvitationList {\n");
-    
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    userInvitations: ").append(toIndentedString(userInvitations)).append("\n");
-    sb.append("    more: ").append(toIndentedString(more)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationSchema.java
@@ -26,7 +26,6 @@ import java.time.OffsetDateTime;
 /**
  * UserInvitationSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class UserInvitationSchema {
   @JsonProperty("email")
   private String email = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationSchemaRegistrationReport.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/UserInvitationSchemaRegistrationReport.java
@@ -28,7 +28,6 @@ import io.swagger.annotations.ApiModelProperty;
  * An high level overview of information about the registration of the user to the invitation.
  */
 @ApiModel(description = "An high level overview of information about the registration of the user to the invitation.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class UserInvitationSchemaRegistrationReport {
   @JsonProperty("complete")
   private RegistrationCompletion complete = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAccount.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAccount.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4124-account-object
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4124-account-object")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiAccount {
   @JsonProperty("homePage")
   private String homePage = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiActivity.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiActivity.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4141-when-the-objecttype-is-activity
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4141-when-the-objecttype-is-activity")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiActivity {
   @JsonProperty("objectType")
   private String objectType = "Activity";

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiActivityDefinition.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiActivityDefinition.java
@@ -30,7 +30,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#activity-definition
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#activity-definition")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiActivityDefinition {
   @JsonProperty("name")
   private Map<String, String> name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAgentGroup.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAgentGroup.java
@@ -29,7 +29,6 @@ import java.util.List;
  * YAML 2.0 does not support oneOf so this is used when object can be an Agent or a Group.
  */
 @ApiModel(description = "YAML 2.0 does not support oneOf so this is used when object can be an Agent or a Group.")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiAgentGroup {
   /**
    * Gets or Sets objectType

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAttachment.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiAttachment.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4111-attachments
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4111-attachments")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiAttachment {
   @JsonProperty("usageType")
   private String usageType = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiContext.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiContext.java
@@ -31,7 +31,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#416-context
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#416-context")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiContext {
   @JsonProperty("registration")
   private String registration = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiContextActivity.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiContextActivity.java
@@ -28,7 +28,6 @@ import java.util.List;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4162-contextactivities-property
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4162-contextactivities-property")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiContextActivity {
   @JsonProperty("parent")
   private List<XapiActivity> parent = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialAuthTypeSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialAuthTypeSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiCredentialAuthTypeSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialAuthTypeSchema {
   /**
    * Gets or Sets xapiCredentialAuthType

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPermissionsLevelSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPermissionsLevelSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiCredentialPermissionsLevelSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialPermissionsLevelSchema {
   /**
    * Gets or Sets xapiCredentialPermissionsLevel

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPostSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPostSchema.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiCredentialPostSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialPostSchema {
   @JsonProperty("name")
   private String name = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPutSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialPutSchema.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiCredentialPutSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialPutSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialSchema.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiCredentialSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialsListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiCredentialsListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * XapiCredentialsListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiCredentialsListSchema {
   @JsonProperty("xapiCredentials")
   private List<XapiCredentialSchema> xapiCredentials = new ArrayList<>();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiEndpointSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiEndpointSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiEndpointSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiEndpointSchema {
   @JsonProperty("url")
   private String url = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiInteractionComponent.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiInteractionComponent.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#interaction-components
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#interaction-components")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiInteractionComponent {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiResult.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiResult.java
@@ -29,7 +29,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#415-result
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#415-result")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiResult {
   @JsonProperty("score")
   private XapiScore score = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiScore.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiScore.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4151-score
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#4151-score")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiScore {
   @JsonProperty("scaled")
   private Double scaled = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatement.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatement.java
@@ -36,7 +36,6 @@ import java.util.List;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#41-statement-properties
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#41-statement-properties")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatement {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipeListSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipeListSchema.java
@@ -27,7 +27,6 @@ import java.util.List;
 /**
  * XapiStatementPipeListSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementPipeListSchema {
   @JsonProperty("xapiStatementPipes")
   private List<XapiStatementPipeSchema> xapiStatementPipes = new ArrayList<>();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipePostSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipePostSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiStatementPipePostSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementPipePostSchema {
   @JsonProperty("source")
   private XapiEndpointSchema source = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipePutSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipePutSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiStatementPipePutSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementPipePutSchema {
   @JsonProperty("source")
   private XapiEndpointSchema source = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipeSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementPipeSchema.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * XapiStatementPipeSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementPipeSchema {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementReference.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementReference.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#statement-references
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#statement-references")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementReference {
   @JsonProperty("objectType")
   private String objectType = "StatementRef";

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementResult.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiStatementResult.java
@@ -28,7 +28,6 @@ import java.util.List;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#42-retrieval-of-statements
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#42-retrieval-of-statements")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiStatementResult {
   @JsonProperty("statements")
   private List<XapiStatement> statements = new ArrayList<>();

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiVerb.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/XapiVerb.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#413-verb
  */
 @ApiModel(description = "https://github.com/adlnet/xAPI-Spec/blob/1.0.2/xAPI.md#413-verb")
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class XapiVerb {
   @JsonProperty("id")
   private String id = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ZoomiCompanyId.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ZoomiCompanyId.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ZoomiCompanyId
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ZoomiCompanyId {
   @JsonProperty("zoomi_company_id")
   private String zoomiCompanyId = null;

--- a/src/main/java/com/rusticisoftware/cloud/v2/client/model/ZoomiCourseOptionsSchema.java
+++ b/src/main/java/com/rusticisoftware/cloud/v2/client/model/ZoomiCourseOptionsSchema.java
@@ -24,7 +24,6 @@ import io.swagger.annotations.ApiModelProperty;
 /**
  * ZoomiCourseOptionsSchema
  */
-@javax.annotation.Generated(value = "io.swagger.codegen.languages.JavaClientCodegen", date = "2022-09-26T11:33:06.485-05:00")
 public class ZoomiCourseOptionsSchema {
   @JsonProperty("nti")
   private String nti = null;


### PR DESCRIPTION
## New Features:
- Added additional app management service endpoint
  - GetApplications - Get a paginated list of applications

## Updates:
- Added `includeTotalCount` parameter to several endpoints to allow for getting a count of matching resources for the provided filter
  - GetApplications
  - GetCourses
  - GetDispatches
  - GetDestinations
  - GetDestinationDispatches
  - GetAllInvitations
  - GetPublicInvitations
  - GetPublicUserInvitations
  - GetPrivateInvitations
  - GetPrivateUserInvitations
  - GetRegistrations
  - GetXapiCredentials
- Updated Jackson version requirement

## Removals/ Deprecations:
- Removed Unsecured auth type in favor of supplying no auth
  - This type was originally added for jumping through some hoops internally to represent no authentication. This has been remedied and is no longer required
- Deprecated GetApplicationList in favor of GetApplications
  - The new endpoint provides additional values that were not previously available due to performance concerns with adding them to the old endpoint